### PR TITLE
New content repository type and updated the ContentFor helper method

### DIFF
--- a/ReallyTinyCms/Core/Storage/ReadOnlyHttpContentRepository.cs
+++ b/ReallyTinyCms/Core/Storage/ReadOnlyHttpContentRepository.cs
@@ -1,0 +1,68 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Xml.Linq;
+using ReallyTinyCms.Core.Model;
+
+namespace ReallyTinyCms.Core.Storage
+{
+    public class ReadOnlyHttpContentRepository : ICmsContentRepository
+    {
+        private readonly string _baseUrl;
+
+        public ReadOnlyHttpContentRepository(string baseUrl)
+        {
+            _baseUrl = baseUrl.TrimEnd('/');
+        }
+
+        public IList<CmsContentItem> RetrieveAll()
+        {
+            var xml = XDocument.Load(_baseUrl+"/all");
+            return (from c in xml.Element("content").Elements("contentItem")
+                    select new CmsContentItem(c.Element("slug").Value)
+                    {
+                        Content = c.Element("content").Value
+                    }
+                   ).ToList();
+
+        }
+
+        public CmsContentItem Retrieve(string contentItemName)
+        {
+            string content = string.Empty;
+            try
+            {
+                content = new WebClient().DownloadString(_baseUrl + contentItemName);
+            } finally
+            {
+                content = "";
+            }
+            return new CmsContentItem(contentItemName)
+            {
+                Content = content
+            };
+        }
+
+        public void SaveOrUpdate(CmsContentItem item)
+        {
+            throw new NotImplementedException();
+        }
+
+        public void Delete(string contentItemName)
+        {
+            throw new NotImplementedException();
+        }
+
+        public bool StorageExists()
+        {
+            var xml = XDocument.Load(_baseUrl + "/all");
+            return xml.Element("content") != null;
+        }
+
+        public void CreateStorage()
+        {
+            throw new NotImplementedException();
+        }
+    }
+}

--- a/ReallyTinyCms/Mvc/HtmlHelperExtensionsForReallyTinyCms.cs
+++ b/ReallyTinyCms/Mvc/HtmlHelperExtensionsForReallyTinyCms.cs
@@ -26,14 +26,18 @@ namespace ReallyTinyCms.Mvc
             {
                 action = () => string.Empty;
             }
+            var contentItem = ContentService.ContentFor(contentItemName, action);
 
-            var currentModel = helper.ViewData.Model; //Support implementing in existing applications
-            helper.ViewData.Model = ContentService.ContentFor(contentItemName, action);
+            if (EditEnabledForCurrentRequest(helper))
+            {
+                var currentModel = helper.ViewData.Model; //Support implementing in existing applications
+                helper.ViewData.Model = contentItem;
+                var content = EditorContentTemplate(helper, contentItemName);
+                helper.ViewData.Model = currentModel;
+                return content;
+            }
 
-            var content = EditEnabledForCurrentRequest(helper) ? EditorContentTemplate(helper, contentItemName) : helper.DisplayForModel(contentItemName, DisplayContentHtmlFieldNamePrefix + contentItemName); ;
-            helper.ViewData.Model = currentModel;
-
-            return content;
+            return MvcHtmlString.Create(contentItem);
         }
 
         private static MvcHtmlString EditorContentTemplate(HtmlHelper helper, string contentItemName)

--- a/ReallyTinyCms/ReallyTinyCms.csproj
+++ b/ReallyTinyCms/ReallyTinyCms.csproj
@@ -53,6 +53,7 @@
     <Compile Include="Core\Model\CmsContentItem.cs" />
     <Compile Include="Core\ContentService.cs" />
     <Compile Include="Core\ContentSourceRegistration.cs" />
+    <Compile Include="Core\Storage\ReadOnlyHttpContentRepository.cs" />
     <Compile Include="Core\Storage\SqlCmsContentRepository.cs" />
     <Compile Include="Core\Storage\Dapper\SqlMapper.cs" />
     <Compile Include="ExtensionsToHelpDuringConfiguration.cs" />


### PR DESCRIPTION
ContentFor() was encoding the content because it was using DisplayFor() (needlessly it seems?)

Replaced with the much simpler:

return MvcHtmlString.Create(contentItem)

And this doesn't encode your HTML
